### PR TITLE
Add bioconda badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ If you write Python code to work with PGS, the underlying libraries for the apps
 
 | Library            | Description                                              | Link                                                                                              |
 |--------------------|----------------------------------------------------------|---------------------------------------------------------------------------------------------------|
-| `pgscatalog-core`  | Core classes and functions to work with PGS data         | [API reference](https://pygscatalog.readthedocs.io/en/latest/autoapi/pgscatalog/core/index.html)  |
-| `pgscatalog-match` | Variant matching across scoring files and target genomes | [API reference](https://pygscatalog.readthedocs.io/en/latest/autoapi/pgscatalog/match/index.html) |
-| `pgscatalog-calc`  | Genetic ancestry similarity estimation and normalisation | [API reference](https://pygscatalog.readthedocs.io/en/latest/autoapi/pgscatalog/calc/index.html)  |
+| `pgscatalog.core`  | Core classes and functions to work with PGS data         | [API reference](https://pygscatalog.readthedocs.io/en/latest/autoapi/pgscatalog/core/index.html)  |
+| `pgscatalog.match` | Variant matching across scoring files and target genomes | [API reference](https://pygscatalog.readthedocs.io/en/latest/autoapi/pgscatalog/match/index.html) |
+| `pgscatalog.calc`  | Genetic ancestry similarity estimation and normalisation | [API reference](https://pygscatalog.readthedocs.io/en/latest/autoapi/pgscatalog/calc/index.html)  |
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ workflow for calculating PGS and performing common adjustments for genetic ances
 If you want an automatic method of calculating PGS, including genetic ancestry similarity estimation and PGS normalisation, 
 the workflow is the easiest method.
 
+> [!TIP]
+> If you want to use all of the applications listed below, you can install the package `pgscatalog-utils` with [pip](https://pypi.org/project/pgscatalog-utils/) or [bioconda](http://bioconda.github.io/recipes/pgscatalog-utils/README.html)
 
 | Application                  | Description                                                            | Install                         | Link                                 |
 |------------------------------|------------------------------------------------------------------------|---------------------------------|--------------------------------------|
@@ -32,9 +34,6 @@ the workflow is the easiest method.
 | `pgscatalog-intersect`       | Match variants across two different variant information files (e.g. reference & target genomes) | `pipx install pgscatalog.match` | [README](https://pygscatalog.readthedocs.io/en/latest/how-to/guides/intersect.html) |
 | `pgscatalog-aggregate`       | Aggregate calculated PGS split across multiple files                   | `pipx install pgscatalog.calc`  | [README](https://pygscatalog.readthedocs.io/en/latest/how-to/guides/aggregate.html)  |
 | `pgscatalog-ancestry-adjust` | Adjust calculated PGS in the context of genetic ancestry               | `pipx install pgscatalog.calc`  | [README](https://pygscatalog.readthedocs.io/en/latest/how-to/guides/ancestry.html)  |
-
-> [!TIP]
-> If you want to use all of these applications, you can install the package `pgscatalog-utils` with [pip](https://pypi.org/project/pgscatalog-utils/) or [bioconda](http://bioconda.github.io/recipes/pgscatalog-utils/README.html)
 
 ## Developer libraries
 

--- a/README.md
+++ b/README.md
@@ -24,15 +24,17 @@ the workflow is the easiest method.
 
 | Application                  | Description                                                            | Install                         | Link                                 |
 |------------------------------|------------------------------------------------------------------------|---------------------------------|--------------------------------------|
-| `pgscatalog-download`        | Download scoring files from the PGS Catalog in specific genome builds  | `pipx install pgscatalog-core`  | [README](https://pygscatalog.readthedocs.io/en/latest/how-to/guides/download.html)  |
-| `pgscatalog-combine`         | Combine multiple scoring files into a consistent structure             | `pipx install pgscatalog-core`  | [README](https://pygscatalog.readthedocs.io/en/latest/how-to/guides/combine.html)  |
-| `pgscatalog-relabel`         | Relabel values in a column based on values in a column in another file | `pipx install pgscatalog-core`  | [README](pgscatalog.core/README.md)  |
-| `pgscatalog-match`           | Match structured scoring file to variants in target genomes            | `pipx install pgscatalog-match` | [README](https://pygscatalog.readthedocs.io/en/latest/how-to/guides/match.html) |
-| `pgscatalog-matchmerge`      | Merge variant match results, useful on larger datasets                 | `pipx install pgscatalog-match` | [README](https://pygscatalog.readthedocs.io/en/latest/how-to/guides/match.html) |
-| `pgscatalog-intersect`       | Match variants across two different variant information files (e.g. reference & target genomes) | `pipx install pgscatalog-match` | [README](https://pygscatalog.readthedocs.io/en/latest/how-to/guides/intersect.html) |
-| `pgscatalog-aggregate`       | Aggregate calculated PGS split across multiple files                   | `pipx install pgscatalog-calc`  | [README](https://pygscatalog.readthedocs.io/en/latest/how-to/guides/aggregate.html)  |
-| `pgscatalog-ancestry-adjust` | Adjust calculated PGS in the context of genetic ancestry               | `pipx install pgscatalog-calc`  | [README](https://pygscatalog.readthedocs.io/en/latest/how-to/guides/ancestry.html)  |
+| `pgscatalog-download`        | Download scoring files from the PGS Catalog in specific genome builds  | `pipx install pgscatalog.core`  | [README](https://pygscatalog.readthedocs.io/en/latest/how-to/guides/download.html)  |
+| `pgscatalog-combine`         | Combine multiple scoring files into a consistent structure             | `pipx install pgscatalog.core`  | [README](https://pygscatalog.readthedocs.io/en/latest/how-to/guides/combine.html)  |
+| `pgscatalog-relabel`         | Relabel values in a column based on values in a column in another file | `pipx install pgscatalog.core`  | [README](pgscatalog.core/README.md)  |
+| `pgscatalog-match`           | Match structured scoring file to variants in target genomes            | `pipx install pgscatalog.match` | [README](https://pygscatalog.readthedocs.io/en/latest/how-to/guides/match.html) |
+| `pgscatalog-matchmerge`      | Merge variant match results, useful on larger datasets                 | `pipx install pgscatalog.match` | [README](https://pygscatalog.readthedocs.io/en/latest/how-to/guides/match.html) |
+| `pgscatalog-intersect`       | Match variants across two different variant information files (e.g. reference & target genomes) | `pipx install pgscatalog.match` | [README](https://pygscatalog.readthedocs.io/en/latest/how-to/guides/intersect.html) |
+| `pgscatalog-aggregate`       | Aggregate calculated PGS split across multiple files                   | `pipx install pgscatalog.calc`  | [README](https://pygscatalog.readthedocs.io/en/latest/how-to/guides/aggregate.html)  |
+| `pgscatalog-ancestry-adjust` | Adjust calculated PGS in the context of genetic ancestry               | `pipx install pgscatalog.calc`  | [README](https://pygscatalog.readthedocs.io/en/latest/how-to/guides/ancestry.html)  |
 
+> [!TIP]
+> If you want to use all of these applications, you can install the package `pgscatalog-utils` with [pip](https://pypi.org/project/pgscatalog-utils/) or [bioconda](http://bioconda.github.io/recipes/pgscatalog-utils/README.html)
 
 ## Developer libraries
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ that has been converted to namespace packages for modularity and re-use.
 
 ## User applications 
 
+[![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](http://bioconda.github.io/recipes/pgscatalog-utils/README.html)
+
 These CLI applications are used internally by the [PGS Catalog Calculator (`pgsc_calc`)](https://github.com/PGScatalog/pgsc_calc) 
 workflow for calculating PGS and performing common adjustments for genetic ancestry. 
 

--- a/pgscatalog.calc/README.md
+++ b/pgscatalog.calc/README.md
@@ -21,6 +21,8 @@ Please note this package doesn't contain functionality to calculate a PGS from t
 
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](http://bioconda.github.io/recipes/pgscatalog.calc/README.html)
 
+or [install via `pip`](https://pypi.org/project/pgscatalog.calc/):
+
 ```
 $ pipx install pgscatalog.calc
 ```

--- a/pgscatalog.calc/README.md
+++ b/pgscatalog.calc/README.md
@@ -1,4 +1,4 @@
-# `pgscatalog-calc`
+# `pgscatalog.calc`
 
 [![Run pytest on pgscatalog.calc](https://github.com/PGScatalog/pygscatalog/actions/workflows/calc-pytest.yml/badge.svg)](https://github.com/PGScatalog/pygscatalog/actions/workflows/calc-pytest.yml)
 [![Documentation Status](https://readthedocs.org/projects/pygscatalog/badge/?version=latest)](https://pygscatalog.readthedocs.io/en/latest/autoapi/pgscatalog/calc/index.html)
@@ -19,8 +19,10 @@ Please note this package doesn't contain functionality to calculate a PGS from t
 
 ## Installation 
 
+[![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](http://bioconda.github.io/recipes/pgscatalog.calc/README.html)
+
 ```
-$ pipx install pgscatalog-calc
+$ pipx install pgscatalog.calc
 ```
 
 ## Documentation

--- a/pgscatalog.core/README.md
+++ b/pgscatalog.core/README.md
@@ -22,6 +22,8 @@ If you want to do automatic PGS calculation check out the [PGS Catalog Calculato
 
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](http://bioconda.github.io/recipes/pgscatalog.core/README.html)
 
+or [install via `pip`](https://pypi.org/project/pgscatalog.core/):
+
 ```
 $ pipx install pgscatalog.core
 ```

--- a/pgscatalog.core/README.md
+++ b/pgscatalog.core/README.md
@@ -1,4 +1,4 @@
-# `pgscatalog-core`
+# `pgscatalog.core`
 
 [![Run pytest on pgscatalog.core](https://github.com/PGScatalog/pygscatalog/actions/workflows/core-pytest.yml/badge.svg)](https://github.com/PGScatalog/pygscatalog/actions/workflows/core-pytest.yml)
 [![Documentation Status](https://readthedocs.org/projects/pygscatalog/badge/?version=latest)](https://pygscatalog.readthedocs.io/en/latest/autoapi/pgscatalog/core/index.html)
@@ -23,7 +23,7 @@ If you want to do automatic PGS calculation check out the [PGS Catalog Calculato
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](http://bioconda.github.io/recipes/pgscatalog.core/README.html)
 
 ```
-$ pipx install pgscatalog-core
+$ pipx install pgscatalog.core
 ```
 
 ## Documentation

--- a/pgscatalog.core/README.md
+++ b/pgscatalog.core/README.md
@@ -20,6 +20,8 @@ If you want to do automatic PGS calculation check out the [PGS Catalog Calculato
 
 ## Installation 
 
+[![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](http://bioconda.github.io/recipes/pgscatalog.core/README.html)
+
 ```
 $ pipx install pgscatalog-core
 ```

--- a/pgscatalog.match/README.md
+++ b/pgscatalog.match/README.md
@@ -1,4 +1,4 @@
-# pgscatalog-match
+# pgscatalog.match
 
 [![.github/workflows/match-pytest.yml](https://github.com/PGScatalog/pygscatalog/actions/workflows/match-pytest.yml/badge.svg?branch=main)](https://github.com/PGScatalog/pygscatalog/actions/workflows/match-pytest.yml)
 [![Documentation Status](https://readthedocs.org/projects/pygscatalog/badge/?version=latest)](https://pygscatalog.readthedocs.io/en/latest/autoapi/pgscatalog/match/index.html)
@@ -14,8 +14,12 @@ If you want to do automatic PGS calculation check out the [PGS Catalog Calculato
 
 ## Installation 
 
+[![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](http://bioconda.github.io/recipes/pgscatalog.match/README.html)
+
+or [install via `pip`](https://pypi.org/project/pgscatalog.match/):
+
 ```
-$ pipx install pgscatalog-match
+$ pipx install pgscatalog.match
 ```
 
 ## Documentation

--- a/pgscatalog.utils/README.md
+++ b/pgscatalog.utils/README.md
@@ -19,8 +19,12 @@ See https://github.com/PGScatalog/pygscatalog for more details.
 
 ## Installation 
 
+[![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](http://bioconda.github.io/recipes/pgscatalog-utils/README.html)
+
+or [install via `pip`](https://pypi.org/project/pgscatalog-utils/):
+
 ```
-$ pip install pgscatalog-utils
+$ pipx install pgscatalog-utils
 ```
 
 ## Documentation 


### PR DESCRIPTION
Add bioconda badges and make package names consistent e.g.:

`pgscatalog-core -> pgscatalog.core`

It worked before because pip would would normalise the package name but we should use the actual package names wherever possible 