### PR TITLE
Fix variant deduplication

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -11,5 +11,5 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: chartboost/ruff-action@v1

--- a/pgscatalog.match/tests/data/duplicated_scorefile.txt
+++ b/pgscatalog.match/tests/data/duplicated_scorefile.txt
@@ -1,0 +1,5 @@
+chr_name	chr_position	effect_allele	other_allele	effect_weight	effect_type	is_duplicated	accession	row_nr
+11	69331418	C	T	0.210422987	additive	FALSE	test	0
+11	69331418	T	C	0.210422987	additive	FALSE	test2	1
+11	69379161	A	C	0.018723614	additive	FALSE	test2	2
+5	1279790	T	C	-0.005213567	additive	FALSE	test3	4


### PR DESCRIPTION
Looking at the coverage reports, the deduplication function hasn't been correctly called since the refactor from the old `pgscatalog-utils` python package (it was accidentally overlooked)

Without this patch, duplicated variants IDs are written to scoring files. When newer versions of plink2 use these variants, a warning is emitted:

```
n --score file entry was skipped due to a missing variant ID
```

Duplicate variant IDs used to trigger an error 🤔 

For context, this is a problem that happens when combining many scores in parallel which share the same variant ID but have different effect alleles. The correct behaviour should be to split these variants across different scoring files. 