### PR TITLE
fix missing log information

### DIFF
--- a/pgscatalog.match/src/pgscatalog/match/cli/_write.py
+++ b/pgscatalog.match/src/pgscatalog/match/cli/_write.py
@@ -47,7 +47,7 @@ def write_matches(matchresults, score_df):
         write_log(matchresults=matchresults, score_df=score_df)
 
     # returns labelled and filtered data for checking after merging
-    return matchresults.df
+    return matchresults.filtered_matches
 
 
 def write_log(matchresults, score_df):


### PR DESCRIPTION
Closes #41 

* Make the log using labelled match candidates, not filtered variants 
* Stop mutating the internal MatchResults dataframe, instead store lazyframes as separate properties to make the state of the internal dataframes clearer 