### PR TITLE
Gradually introduce type checking

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,4 +1,4 @@
-name: Run pytest
+name: Run pytest and mypy
 
 on:
   workflow_call:
@@ -62,3 +62,28 @@ jobs:
             fail_ci_if_error: true
             slug: PGScatalog/pygscatalog
             flags: ${{ inputs.package-directory }}
+            
+  mypy:
+      runs-on: ubuntu-latest
+
+      steps:
+        - uses: actions/checkout@v4
+
+        - name: Install Python
+          uses: actions/setup-python@v5
+          with:
+            python-version: ${{ inputs.python-version }}
+            cache: 'pip'
+
+        - uses: actions/cache@v4
+          with:
+            path: ${{ inputs.package-directory }}/.venv
+            key: venv-${{ hashFiles('**/poetry.lock') }}
+
+        - run: pip install poetry
+
+        - run: poetry install --with dev --all-extras
+          working-directory: ${{ inputs.package-directory }}
+
+        - run: mypy # import to run in top level directory
+

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -75,15 +75,7 @@ jobs:
             python-version: ${{ inputs.python-version }}
             cache: 'pip'
 
-        - uses: actions/cache@v4
-          with:
-            path: ${{ inputs.package-directory }}/.venv
-            key: venv-${{ hashFiles('**/poetry.lock') }}
-
-        - run: pip install poetry
-
-        - run: poetry install --with dev --all-extras
-          working-directory: ${{ inputs.package-directory }}
+        - run: pip install mypy
 
         - run: mypy # import to run in top level directory
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,8 @@ repos:
     - id: ruff
       args: [ --fix ]
     - id: ruff-format
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: 'v1.11.2'  # Use the sha / tag you want to point at
+  hooks:
+    - id: mypy
+      args: [--config-file, mypy.ini]

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,10 @@
+[mypy]
+files = pgscatalog.core/**/*.py
+exclude = [pgscatalog.calc, pgscatalog.match]
+
+warn_unused_configs = True
+ignore_missing_imports = true
+follow_imports = silent
+disallow_untyped_calls = false
+disallow_incomplete_defs = true
+

--- a/pgscatalog.core/poetry.lock
+++ b/pgscatalog.core/poetry.lock
@@ -577,6 +577,64 @@ files = [
 ]
 
 [[package]]
+name = "mypy"
+version = "1.11.2"
+description = "Optional static typing for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "mypy-1.11.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d42a6dd818ffce7be66cce644f1dff482f1d97c53ca70908dff0b9ddc120b77a"},
+    {file = "mypy-1.11.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:801780c56d1cdb896eacd5619a83e427ce436d86a3bdf9112527f24a66618fef"},
+    {file = "mypy-1.11.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:41ea707d036a5307ac674ea172875f40c9d55c5394f888b168033177fce47383"},
+    {file = "mypy-1.11.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6e658bd2d20565ea86da7d91331b0eed6d2eee22dc031579e6297f3e12c758c8"},
+    {file = "mypy-1.11.2-cp310-cp310-win_amd64.whl", hash = "sha256:478db5f5036817fe45adb7332d927daa62417159d49783041338921dcf646fc7"},
+    {file = "mypy-1.11.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:75746e06d5fa1e91bfd5432448d00d34593b52e7e91a187d981d08d1f33d4385"},
+    {file = "mypy-1.11.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a976775ab2256aadc6add633d44f100a2517d2388906ec4f13231fafbb0eccca"},
+    {file = "mypy-1.11.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cd953f221ac1379050a8a646585a29574488974f79d8082cedef62744f0a0104"},
+    {file = "mypy-1.11.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:57555a7715c0a34421013144a33d280e73c08df70f3a18a552938587ce9274f4"},
+    {file = "mypy-1.11.2-cp311-cp311-win_amd64.whl", hash = "sha256:36383a4fcbad95f2657642a07ba22ff797de26277158f1cc7bd234821468b1b6"},
+    {file = "mypy-1.11.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:e8960dbbbf36906c5c0b7f4fbf2f0c7ffb20f4898e6a879fcf56a41a08b0d318"},
+    {file = "mypy-1.11.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:06d26c277962f3fb50e13044674aa10553981ae514288cb7d0a738f495550b36"},
+    {file = "mypy-1.11.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6e7184632d89d677973a14d00ae4d03214c8bc301ceefcdaf5c474866814c987"},
+    {file = "mypy-1.11.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3a66169b92452f72117e2da3a576087025449018afc2d8e9bfe5ffab865709ca"},
+    {file = "mypy-1.11.2-cp312-cp312-win_amd64.whl", hash = "sha256:969ea3ef09617aff826885a22ece0ddef69d95852cdad2f60c8bb06bf1f71f70"},
+    {file = "mypy-1.11.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:37c7fa6121c1cdfcaac97ce3d3b5588e847aa79b580c1e922bb5d5d2902df19b"},
+    {file = "mypy-1.11.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4a8a53bc3ffbd161b5b2a4fff2f0f1e23a33b0168f1c0778ec70e1a3d66deb86"},
+    {file = "mypy-1.11.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ff93107f01968ed834f4256bc1fc4475e2fecf6c661260066a985b52741ddce"},
+    {file = "mypy-1.11.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:edb91dded4df17eae4537668b23f0ff6baf3707683734b6a818d5b9d0c0c31a1"},
+    {file = "mypy-1.11.2-cp38-cp38-win_amd64.whl", hash = "sha256:ee23de8530d99b6db0573c4ef4bd8f39a2a6f9b60655bf7a1357e585a3486f2b"},
+    {file = "mypy-1.11.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:801ca29f43d5acce85f8e999b1e431fb479cb02d0e11deb7d2abb56bdaf24fd6"},
+    {file = "mypy-1.11.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:af8d155170fcf87a2afb55b35dc1a0ac21df4431e7d96717621962e4b9192e70"},
+    {file = "mypy-1.11.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f7821776e5c4286b6a13138cc935e2e9b6fde05e081bdebf5cdb2bb97c9df81d"},
+    {file = "mypy-1.11.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:539c570477a96a4e6fb718b8d5c3e0c0eba1f485df13f86d2970c91f0673148d"},
+    {file = "mypy-1.11.2-cp39-cp39-win_amd64.whl", hash = "sha256:3f14cd3d386ac4d05c5a39a51b84387403dadbd936e17cb35882134d4f8f0d24"},
+    {file = "mypy-1.11.2-py3-none-any.whl", hash = "sha256:b499bc07dbdcd3de92b0a8b29fdf592c111276f6a12fe29c30f6c417dd546d12"},
+    {file = "mypy-1.11.2.tar.gz", hash = "sha256:7f9993ad3e0ffdc95c2a14b66dee63729f021968bff8ad911867579c65d13a79"},
+]
+
+[package.dependencies]
+mypy-extensions = ">=1.0.0"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typing-extensions = ">=4.6.0"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+install-types = ["pip"]
+mypyc = ["setuptools (>=50)"]
+reports = ["lxml"]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.0.0"
+description = "Type system extensions for programs checked with the mypy type checker."
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
+]
+
+[[package]]
 name = "natsort"
 version = "8.4.0"
 description = "Simple yet flexible natural sorting in Python."
@@ -643,8 +701,8 @@ files = [
 annotated-types = ">=0.4.0"
 pydantic-core = "2.23.2"
 typing-extensions = [
-    {version = ">=4.12.2", markers = "python_version >= \"3.13\""},
     {version = ">=4.6.1", markers = "python_version < \"3.13\""},
+    {version = ">=4.12.2", markers = "python_version >= \"3.13\""},
 ]
 tzdata = {version = "*", markers = "python_version >= \"3.9\""}
 
@@ -957,8 +1015,8 @@ files = [
 
 [package.dependencies]
 astroid = [
-    {version = ">=3.0.0a1", markers = "python_version >= \"3.12\""},
     {version = ">=2.7", markers = "python_version < \"3.12\""},
+    {version = ">=3.0.0a1", markers = "python_version >= \"3.12\""},
 ]
 Jinja2 = "*"
 PyYAML = "*"
@@ -1282,4 +1340,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10"
-content-hash = "0d2b6f30ec82005f32dc6f086740b5ef7f511ce2a207541557057e3b35890420"
+content-hash = "ced3ebc8801750443914b8181af402a4e7e389ef8d2639fef3dc02ecd9b7ff47"

--- a/pgscatalog.core/pyproject.toml
+++ b/pgscatalog.core/pyproject.toml
@@ -28,6 +28,7 @@ pydantic = "^2.9.0"
 pytest = "^7.4.4"
 sphinx-autoapi = "^3.0.0"
 pytest-cov = "^4.1.0"
+mypy = "^1.11.2"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pgscatalog.core/src/pgscatalog/core/__init__.py
+++ b/pgscatalog.core/src/pgscatalog/core/__init__.py
@@ -1,4 +1,5 @@
-""" Public interface to the Polygenic Score Catalog core package """
+"""Public interface to the Polygenic Score Catalog core package"""
+
 import logging
 import importlib.metadata
 

--- a/pgscatalog.core/src/pgscatalog/core/lib/_read.py
+++ b/pgscatalog.core/src/pgscatalog/core/lib/_read.py
@@ -3,6 +3,7 @@ These functions aren't really meant to be imported outside corelib"""
 
 import logging
 import pathlib
+from typing import Generator, Iterator
 
 from xopen import xopen
 
@@ -12,8 +13,13 @@ logger = logging.getLogger(__name__)
 
 
 def read_rows_lazy(
-    *, csv_reader, fields: list[str], name: str, wide: bool, row_nr: int
-):
+    *,
+    csv_reader: Iterator[list[str]],
+    fields: list[str],
+    name: str,
+    wide: bool,
+    row_nr: int,
+) -> Generator[ScoreVariant, None, None]:
     """Read rows from an open scoring file and instantiate them as ScoreVariants"""
     for row in csv_reader:
         variant = dict(zip(fields, row))
@@ -81,7 +87,7 @@ def detect_wide(cols: list[str]) -> bool:
         return False
 
 
-def read_header(path: pathlib.Path):
+def read_header(path: pathlib.Path) -> dict:
     """Parses the header of a PGS Catalog format scoring file into a dictionary"""
     header = {}
 

--- a/pgscatalog.core/src/pgscatalog/core/lib/_sortpaths.py
+++ b/pgscatalog.core/src/pgscatalog/core/lib/_sortpaths.py
@@ -1,7 +1,8 @@
-""" This module assumes you're working with paths that follow the format:
+"""This module assumes you're working with paths that follow the format:
 
 {sampleset}_{chrom}_{effect_type}_{n}
 """
+
 from natsort import natsort_keygen, ns
 
 

--- a/pgscatalog.core/src/pgscatalog/core/lib/models.py
+++ b/pgscatalog.core/src/pgscatalog/core/lib/models.py
@@ -1,4 +1,4 @@
-""" PGS Catalog pydantic models for data validation
+"""PGS Catalog pydantic models for data validation
 
 Best way to reuse:
 
@@ -7,9 +7,10 @@ Best way to reuse:
   * `import pgscatalog.core` and use fully qualified name: `pgscatalog.core.models.CatalogScoreVariant`)
 
 """
+
 from functools import cached_property
 from typing import ClassVar, Optional
-from typing_extensions import Self
+from typing_extensions import Self, Literal
 
 from pydantic import (
     BaseModel,
@@ -46,7 +47,7 @@ class Allele(BaseModel):
     allele: str
     _valid_snp_bases: ClassVar[frozenset[str]] = frozenset({"A", "C", "T", "G"})
 
-    @computed_field
+    @computed_field  # type: ignore
     @cached_property
     def is_snp(self) -> bool:
         """SNPs are the most common type of effect allele in PGS Catalog scoring
@@ -242,23 +243,35 @@ class CatalogScoreVariant(BaseModel):
     )
 
     # helpful class attributes (not used by pydantic to instantiate a class)
-    harmonised_columns: ClassVar[tuple[str]] = (
+    harmonised_columns: ClassVar[
+        tuple[Literal["hm_rsID"], Literal["hm_chr"], Literal["hm_pos"]]
+    ] = (
         "hm_rsID",
         "hm_chr",
         "hm_pos",
     )  # it's OK if (""hm_source", "hm_inferOtherAllele", "hm_match_chr", "hm_match_pos") are missing
-    complex_columns: ClassVar[tuple[str]] = (
+    complex_columns: ClassVar[
+        tuple[
+            Literal["is_haplotype"], Literal["is_diplotype"], Literal["is_interaction"]
+        ]
+    ] = (
         "is_haplotype",
         "is_diplotype",
         "is_interaction",
     )
-    non_additive_columns: ClassVar[tuple[str]] = (
+    non_additive_columns: ClassVar[
+        tuple[
+            Literal["dosage_0_weight"],
+            Literal["dosage_1_weight"],
+            Literal["dosage_2_weight"],
+        ]
+    ] = (
         "dosage_0_weight",
         "dosage_1_weight",
         "dosage_2_weight",
     )
 
-    @computed_field
+    @computed_field  # type: ignore
     @cached_property
     def variant_id(self) -> str:
         """ID = chr:pos:effect_allele:other_allele"""
@@ -269,7 +282,7 @@ class CatalogScoreVariant(BaseModel):
             ]
         )
 
-    @computed_field
+    @computed_field  # type: ignore
     @cached_property
     def is_harmonised(self) -> bool:
         # simple check: do any of the harmonised columns have data?
@@ -278,7 +291,7 @@ class CatalogScoreVariant(BaseModel):
                 return True
         return False
 
-    @computed_field
+    @computed_field  # type: ignore
     @cached_property
     def is_complex(self) -> bool:
         # checking flag fields here, which are defaulted to False
@@ -287,7 +300,7 @@ class CatalogScoreVariant(BaseModel):
                 return True
         return False
 
-    @computed_field
+    @computed_field  # type: ignore
     @cached_property
     def is_non_additive(self) -> bool:
         # simple check: do any of the weight dosage columns have data?
@@ -296,7 +309,7 @@ class CatalogScoreVariant(BaseModel):
                 return True
         return False
 
-    @computed_field
+    @computed_field  # type: ignore
     @cached_property
     def effect_type(self) -> EffectType:
         match (self.is_recessive, self.is_dominant, self.is_non_additive):

--- a/pgscatalog.core/src/pgscatalog/core/lib/scorevariant.py
+++ b/pgscatalog.core/src/pgscatalog/core/lib/scorevariant.py
@@ -1,4 +1,4 @@
-from typing import Optional, ClassVar
+from typing import Optional, ClassVar, Literal
 from pydantic import (
     Field,
     field_serializer,
@@ -62,7 +62,19 @@ class ScoreVariant(CatalogScoreVariant):
     )
 
     # column names for output are used by __iter__ and when writing out
-    output_fields: ClassVar[tuple[str]] = (
+    output_fields: ClassVar[
+        tuple[
+            Literal["chr_name"],
+            Literal["chr_position"],
+            Literal["effect_allele"],
+            Literal["other_allele"],
+            Literal["effect_weight"],
+            Literal["effect_type"],
+            Literal["is_duplicated"],
+            Literal["accession"],
+            Literal["row_nr"],
+        ]
+    ] = (
         "chr_name",
         "chr_position",
         "effect_allele",


### PR DESCRIPTION
Now we're using a lot of type hints with pydantic, it would be sensible to enforce checking them 

mypy has been configured to be pretty relaxed:

* Only check `pgscatalog.core` to start with
* If a function is untyped, it won't be checked
* If a function is typed, it will be checked for type errors
* If a function is partially typed, it will raise an error

As we develop or refactor stuff we can rework functions to have type hints bit by bit

I also added a pre-commit configuration if that's your cup of tea 🍵 
