### PR TITLE
Rate limit downloads from EBI FTP

### DIFF
--- a/pgscatalog.core/src/pgscatalog/core/cli/download_cli.py
+++ b/pgscatalog.core/src/pgscatalog/core/cli/download_cli.py
@@ -42,7 +42,8 @@ def run():
         include_children=args.efo_include_children,
     )
 
-    with ThreadPoolExecutor() as executor:
+    # EBI FTP rate limits ~25 connections per IP
+    with ThreadPoolExecutor(max_workers=10) as executor:
         futures = []
         for scorefile in sfs:
             logger.info(f"Submitting {scorefile!r} download")


### PR DESCRIPTION
When downloading ~1000 scoring files this morning I got temporarily blocked from HTTPS and FTP downloads 👀 

The `ThreadPoolExecutor` spawns a lot of workers:

>  Changed in version 3.8: Default value of max_workers is changed to min(32, os.cpu_count() + 4). This default value preserves at least 5 workers for I/O bound tasks. It utilizes at most 32 CPU cores for CPU bound tasks which release the GIL. And it avoids using very large resources implicitly on many-core machines.

EBI limits transfers to 25 simultaneous active connections per IP.