### PR TITLE
Fix combine CLI producing empty output with invalid data

### DIFF
--- a/pgscatalog.core/pyproject.toml
+++ b/pgscatalog.core/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pgscatalog.core"
-version = "0.3.1"
+version = "0.3.2"
 description = "Core tools for working with polygenic scores (PGS) and the PGS Catalog"
 license = "Apache-2.0"
 authors = ["Benjamin Wingfield <bwingfield@ebi.ac.uk>", "Samuel Lambert <sl925@medschl.cam.ac.uk>", "Laurent Gil <lg10@sanger.ac.uk>"]

--- a/pgscatalog.core/src/pgscatalog/core/cli/combine_cli.py
+++ b/pgscatalog.core/src/pgscatalog/core/cli/combine_cli.py
@@ -87,7 +87,7 @@ def run():
         logger.setLevel(logging.DEBUG)
         logger.debug("Verbose logging enabled")
 
-    out_path = pathlib.Path(args.outfile)
+    out_path = pathlib.Path(args.outfile).resolve()
 
     if out_path.exists():
         logger.critical(f"Output file already exists: {args.outfile}")
@@ -165,7 +165,7 @@ def run():
                 )
             variant_log.append(log)
 
-    if n_finished == 0:
+    if n_finished == 0 or not out_path.exists():
         raise ValueError(
             "Couldn't process any scoring files. Did they all have non-additive weights?"
         )

--- a/pgscatalog.core/src/pgscatalog/core/lib/_normalise.py
+++ b/pgscatalog.core/src/pgscatalog/core/lib/_normalise.py
@@ -155,7 +155,7 @@ def remap_harmonised(variants, harmonised, target_build):
     Perhaps authors submitted rsID and effect allele originally:
 
     >>> from pgscatalog.core.lib.models import ScoreVariant
-    >>> variant = ScoreVariant(**{"chr_position": 1, "rsID": None, "chr_name": "2", "effect_allele": "A", "effect_weight": 5, "accession": "test", "hm_chr": "1", "hm_pos": 100, "hm_rsID": "testrsid", "hm_inferOtherAllele": "A", "row_nr": 0})
+    >>> variant = ScoreVariant(**{"chr_position": 1, "rsID": None, "chr_name": "2", "effect_allele": "A", "effect_weight": 5, "accession": "test", "hm_chr": "1", "hm_pos": 100, "hm_rsID": "rsTEST", "hm_inferOtherAllele": "A", "row_nr": 0})
     >>> variant
     ScoreVariant(..., effect_allele=Allele(allele='A', is_snp=True), other_allele=None, ...
 

--- a/pgscatalog.core/src/pgscatalog/core/lib/models.py
+++ b/pgscatalog.core/src/pgscatalog/core/lib/models.py
@@ -557,8 +557,9 @@ class CatalogScoreVariant(BaseModel):
 
     @model_validator(mode="after")
     def check_rsid_format(self) -> Self:
-        if self.is_hm_bad:
+        if self.is_hm_bad or self.hm_source == "liftover":
             # disable this check when harmonisation fails
+            # variants that have been harmonised by liftover will put coordinates in rsID column
             return self
 
         for x in (self.rsID, self.hm_rsID):

--- a/pgscatalog.core/src/pgscatalog/core/lib/models.py
+++ b/pgscatalog.core/src/pgscatalog/core/lib/models.py
@@ -531,6 +531,7 @@ class CatalogScoreVariant(BaseModel):
         "chr_position",
         "is_haplotype",
         "is_diplotype",
+        "hm_rsID",
         "hm_chr",
         "hm_pos",
         "hm_match_chr",
@@ -545,7 +546,7 @@ class CatalogScoreVariant(BaseModel):
             return None
         return v
 
-    @field_validator("rsID", mode="after")
+    @field_validator("rsID", "hm_rsID", mode="after")
     @classmethod
     def check_rsid_format(cls, rsid: Optional[str]) -> Optional[str]:
         if rsid == ".":

--- a/pgscatalog.core/tests/data/bad_harmonised.txt
+++ b/pgscatalog.core/tests/data/bad_harmonised.txt
@@ -1,0 +1,23 @@
+###PGS CATALOG SCORING FILE - see https://www.pgscatalog.org/downloads/#dl_ftp_scoring for additional information
+#format_version=2.0
+##POLYGENIC SCORE (PGS) INFORMATION
+#pgs_id=PGS003581
+#pgs_name=MTAG.Envs.LifetimeMDD
+#trait_reported=Major Depressive Disorder (Lifetime)
+#trait_mapped=major depressive disorder
+#trait_efo=MONDO_0002009
+#genome_build=GRCh37
+#variants_number=4861398
+#weight_type=beta
+##SOURCE INFORMATION
+#pgp_id=PGP000461
+#citation=Dahl A et al. bioRxiv (2022). doi:10.1101/2022.08.15.503980
+##HARMONIZATION DETAILS
+#HmPOS_build=GRCh38
+#HmPOS_date=2023-04-12
+#HmPOS_match_chr={""True"": null, ""False"": null}
+#HmPOS_match_pos={""True"": null, ""False"": null}
+rsID	effect_allele	other_allele	effect_weight	allelefrequency_effect	variant_description	hm_source	hm_rsID	hm_chr	hm_pos	hm_inferOtherAllele
+.	T	C	0.004040743	0.329683	VARIANT_ID=1:2556125_C_T	Unknown				
+.	T	C	0.004025092	0.329689	VARIANT_ID=1:2556548_C_T	Unknown				
+.	A	G	0.004013246	0.329686	VARIANT_ID=1:2556709_G_A	Unknown				

--- a/pgscatalog.core/tests/data/invalid_scorefile.txt
+++ b/pgscatalog.core/tests/data/invalid_scorefile.txt
@@ -1,0 +1,18 @@
+###PGS CATALOG SCORING FILE - see https://www.pgscatalog.org/downloads/#dl_ftp_scoring for additional information					
+#format_version=2.0					
+##POLYGENIC SCORE (PGS) INFORMATION					
+#pgs_id=PGS003581					
+#pgs_name=MTAG.Envs.LifetimeMDD					
+#trait_reported=Major Depressive Disorder (Lifetime)					
+#trait_mapped=major depressive disorder					
+#trait_efo=MONDO_0002009					
+#genome_build=GRCh37					
+#variants_number=4861398					
+#weight_type=beta					
+##SOURCE INFORMATION					
+#pgp_id=PGP000461					
+#citation=Dahl A et al. bioRxiv (2022). doi:10.1101/2022.08.15.503980					
+rsID	effect_allele	other_allele	effect_weight	allelefrequency_effect	variant_description
+.	T	C	0.004040743	0.329683	VARIANT_ID=1:2556125_C_T
+.	T	C	0.004025092	0.329689	VARIANT_ID=1:2556548_C_T
+.	A	G	0.004013246	0.329686	VARIANT_ID=1:2556709_G_A


### PR DESCRIPTION
When processing a single file, if the combine CLI encountered an invalid variant it would quietly fail to write out any variants (quiet except for a misleading log statement). Some investigation notes:

- [X] The invalid data wasn't invalid (some variants failed harmonisation and were missing mandatory fields)
  - [X]  Update the pydantic models to support this case properly
- [X] The CLI wasn't re-raising exceptions correctly because I had a `return` statement inside a `finally` block 😬 
  - [X] Add tests to make sure badly harmonised variants do create an output file and invalid variants do throw a `ValidationError` exception
  - [X] Add a check to the CLI that an output file actually exists
- [X] Re-test this branch on the entire Catalog and check for exceptions

Closes #55 

### Test results

22 (older) scoring files contain invalid rsIDs:

```
pgscatalog.core.cli.combine_cli: 2024-10-18 14:43:12 CRITICAL PGS000019 contains invalid data, stopping and exploding
pgscatalog.core.cli.combine_cli: 2024-10-18 14:52:23 CRITICAL PGS000042 contains invalid data, stopping and exploding
pgscatalog.core.cli.combine_cli: 2024-10-18 15:09:03 CRITICAL PGS000212 contains invalid data, stopping and exploding
pgscatalog.core.cli.combine_cli: 2024-10-18 15:09:03 CRITICAL PGS000213 contains invalid data, stopping and exploding
pgscatalog.core.cli.combine_cli: 2024-10-18 15:09:03 CRITICAL PGS000214 contains invalid data, stopping and exploding
pgscatalog.core.cli.combine_cli: 2024-10-18 15:09:03 CRITICAL PGS000215 contains invalid data, stopping and exploding
pgscatalog.core.cli.combine_cli: 2024-10-18 15:09:03 CRITICAL PGS000216 contains invalid data, stopping and exploding
pgscatalog.core.cli.combine_cli: 2024-10-18 16:26:04 CRITICAL PGS000310 contains invalid data, stopping and exploding
pgscatalog.core.cli.combine_cli: 2024-10-18 16:26:04 CRITICAL PGS000311 contains invalid data, stopping and exploding
pgscatalog.core.cli.combine_cli: 2024-10-18 16:26:06 CRITICAL PGS000317 contains invalid data, stopping and exploding
pgscatalog.core.cli.combine_cli: 2024-10-18 16:36:01 CRITICAL PGS000330 contains invalid data, stopping and exploding
pgscatalog.core.cli.combine_cli: 2024-10-18 16:46:39 CRITICAL PGS000332 contains invalid data, stopping and exploding
pgscatalog.core.cli.combine_cli: 2024-10-18 16:46:39 CRITICAL PGS000333 contains invalid data, stopping and exploding
pgscatalog.core.cli.combine_cli: 2024-10-18 16:48:31 CRITICAL PGS000344 contains invalid data, stopping and exploding
pgscatalog.core.cli.combine_cli: 2024-10-18 16:48:31 CRITICAL PGS000345 contains invalid data, stopping and exploding
pgscatalog.core.cli.combine_cli: 2024-10-18 16:48:31 CRITICAL PGS000346 contains invalid data, stopping and exploding
pgscatalog.core.cli.combine_cli: 2024-10-18 16:48:31 CRITICAL PGS000347 contains invalid data, stopping and exploding
pgscatalog.core.cli.combine_cli: 2024-10-18 19:14:11 CRITICAL PGS000727 contains invalid data, stopping and exploding
pgscatalog.core.cli.combine_cli: 2024-10-18 19:15:24 CRITICAL PGS000728 contains invalid data, stopping and exploding
pgscatalog.core.cli.combine_cli: 2024-10-18 19:15:24 CRITICAL PGS000729 contains invalid data, stopping and exploding
pgscatalog.core.cli.combine_cli: 2024-10-18 19:22:39 CRITICAL PGS000754 contains invalid data, stopping and exploding
pgscatalog.core.cli.combine_cli: 2024-10-18 19:33:12 CRITICAL PGS000867 contains invalid data, stopping and exploding
```

Fix is to relax the rsID check when harmonisation goes wrong. No other `ValidationErrors` get thrown.