### PR TITLE
Convert OR / HR fields with empty string to None

### DIFF
--- a/pgscatalog.core/src/pgscatalog/core/lib/models.py
+++ b/pgscatalog.core/src/pgscatalog/core/lib/models.py
@@ -538,6 +538,8 @@ class CatalogScoreVariant(BaseModel):
         "hm_match_pos",
         "allelefrequency_effect",
         "variant_type",
+        "OR",
+        "HR",
         mode="before",
     )
     @classmethod


### PR DESCRIPTION
One scoring file in the Catalog(PGSXX4900-ish) has the OR field set to an empty string, which currently raises a validation error