### PR TITLE
Stop `pgscatalog-download` from leaving temporary files in the output directory

### DIFF
--- a/pgscatalog.core/src/pgscatalog/core/lib/_download.py
+++ b/pgscatalog.core/src/pgscatalog/core/lib/_download.py
@@ -89,7 +89,9 @@ def ftp_fallback(retry_state):
         try:
             # if an exception was thrown, get rid of the temporary file
             os.remove(score_f.name)
-            logger.info(f"FTP download failed, deleting {score_f.name}")
+            logger.info(
+                f"FTP download failed, deleting {score_f.name}"
+            )  # pragma: no cover
         except OSError:
             # file has been renamed, that's OK
             pass
@@ -103,7 +105,8 @@ def ftp_fallback(retry_state):
 )
 def https_download(*, url, out_path, directory, overwrite):
     """Download a file from the PGS Catalog over HTTPS, with automatic retries and
-    waiting. md5 checksums are automatically validated."""
+    waiting. md5 checksums are automatically validated.
+    """
     try:
         if Config.FTP_EXCLUSIVE:
             logger.warning("HTTPS downloads disabled by Config.FTP_EXCLUSIVE")
@@ -141,7 +144,7 @@ def https_download(*, url, out_path, directory, overwrite):
         try:
             # if an exception was thrown, get rid of the temporary file
             os.remove(f.name)
-            logger.info(f"HTTPS download failed, deleting {f.name}")
+            logger.info(f"HTTPS download failed, deleting {f.name}")  # pragma: no cover
         except OSError:
             # file has been renamed, that's OK
             pass

--- a/pgscatalog.core/src/pgscatalog/core/lib/_download.py
+++ b/pgscatalog.core/src/pgscatalog/core/lib/_download.py
@@ -129,3 +129,11 @@ def https_download(*, url, out_path, directory, overwrite):
         # no exceptions thrown, move the temporary file to the final output path
         os.rename(f.name, out_path)
         logger.info(f"HTTPS download OK, {out_path} checksum validation passed")
+    finally:
+        try:
+            # if an exception was thrown, get rid of the temporary file
+            os.remove(f.name)
+            logger.info(f"HTTPS download failed, deleting {f.name}")
+        except OSError:
+            # file has been renamed, that's OK
+            pass


### PR DESCRIPTION
If a download fails for any reason, temporary files litter the output directory. When a download is successful and passes checksum validation the temporary file is renamed to `PGSXXXXX.txt.gz`.

Be polite and stop littering 🗑️ 

This didn't affect the calculator because temporary files were ignored by the Nextflow process output wildcard `"PGS*.txt.gz"`