### PR TITLE
Clarify positions are 1-based and enforce in `hm_pos`

### DIFF
--- a/pgscatalog.utils/packages/pgscatalog.core/src/pgscatalog/core/lib/models.py
+++ b/pgscatalog.utils/packages/pgscatalog.core/src/pgscatalog/core/lib/models.py
@@ -195,7 +195,7 @@ class CatalogScoreVariant(BaseModel):
         Field(
             default=None,
             title="Location within the Chromosome",
-            description="Chromosomal position associated with the variant.",
+            description="Chromosomal position associated with the variant. 1-based.",
             gt=0,
         ),
     ]
@@ -388,7 +388,8 @@ class CatalogScoreVariant(BaseModel):
             ge=0,
             default=None,
             title="Harmonized chromosome position",
-            description="Chromosomal position (base pair location) where the variant is located, preferring matches to chromosomes over patches present in later builds.",
+            description="Chromosomal position (base pair location) where the variant is located, preferring matches to chromosomes over patches present in later builds. 1-based.",
+            gt=0,
         ),
     ]
     hm_inferOtherAllele: Annotated[


### PR DESCRIPTION
Given the `gt=0` on `chr_position`, I assume the positions are all intended to be 1-based.
Is that correct? If not I'll update to match.

Also, is the documentation auto-derived from this? I could only see a single instance of the doc-string, and it would be nice for that to also be updated.