### PR TITLE
Fix pgscatalog.calc dependency

### DIFF
--- a/pgscatalog.utils/packages/pgscatalog.calc/pyproject.toml
+++ b/pgscatalog.utils/packages/pgscatalog.calc/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pgscatalog.calc"
-version = "0.3.0"
+version = "0.3.1"
 description = "Libraries and applications for working with calculated polygenic scores"
 license = "Apache-2.0"
 authors = [
@@ -25,11 +25,15 @@ requires-python = ">=3.10"
 dependencies = [
     "numpy~=1.26",
     "pandas~=2.2.0",
-    "pgscatalog-core>=0.3.3",
     "pyarrow~=15.0.0",
     "scikit-learn~=1.4",
     "scipy~=1.12",
+    "pgscatalog-core"
 ]
+
+
+[tool.uv.sources]
+pgscatalog-core = { workspace = true }
 
 # https://peps.python.org/pep-0621/
 [project.scripts]

--- a/pgscatalog.utils/pyproject.toml
+++ b/pgscatalog.utils/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pgscatalog-utils"
-version = "2.0.1"
+version = "2.0.2"
 description = "Utilities for working with PGS Catalog API and scoring files"
 license = "Apache-2.0"
 authors = [


### PR DESCRIPTION
Forgot to reset this dependency when we migrated to a uv workspace 👀 

(hopefully) closes #71 