### PR TITLE
UCSC chain file URLs swapped in format.rst

### DIFF
--- a/docs/how-to/guides/format.rst
+++ b/docs/how-to/guides/format.rst
@@ -52,8 +52,8 @@ First, download chain files from UCSC:
 * `hg19ToHg38.over.chain.gz`_
 * `hg38ToHg19.over.chain.gz`_
 
-.. _hg19ToHg38.over.chain.gz: https://hgdownload.soe.ucsc.edu/goldenPath/hg38/liftOver/
-.. _hg38ToHg19.over.chain.gz: https://hgdownload.soe.ucsc.edu/goldenPath/hg19/liftOver/
+.. _hg19ToHg38.over.chain.gz: https://hgdownload.soe.ucsc.edu/goldenPath/hg19/liftOver/
+.. _hg38ToHg19.over.chain.gz: https://hgdownload.soe.ucsc.edu/goldenPath/hg38/liftOver/
 
 And copy them into a directory (e.g. ``my_chain_dir/``).
 


### PR DESCRIPTION
Swapped URLs so that 'hg19ToHg38.over.chain.gz' points to the page holding the hg19 liftover chains (incl. the hg19ToHg38 chain) and vice-versa